### PR TITLE
Remove global stringsAsFactors=FALSE setting

### DIFF
--- a/R/JTKv3.1p.R
+++ b/R/JTKv3.1p.R
@@ -374,7 +374,6 @@ runJTK <- function(indata,JTKtime,minper=20,maxper=28, releaseNote=TRUE, para = 
   if ( (max(perTK)*freq != maxper) & (releaseNote) )
   {  cat(c("Warning: the input 'maxper' is not suitable for JTK, it was reset as ", max(perTK)*freq, "\n"));  }
 	##read-in data
-	options(stringsAsFactors=FALSE);
 	data <- indata;
 	idorder <- dimnames(data)[[1]];
 	outID <- as.character(data[,1]);           


### PR DESCRIPTION
The global setting `options(stringsAsFactors=FALSE)` appears not to serve any purpose in runJTK(). This, I assume, was an artifact of porting JTK Cycle to a package friendly format (i.e. copied from Run_JTK_CYCLE (Example1).R). This global setting can cause confusing behaviour when writing code using MetaCycle and I would suggest removing this if it causes no problems.